### PR TITLE
Missing Requirements

### DIFF
--- a/lib/dynamics_crm.rb
+++ b/lib/dynamics_crm.rb
@@ -34,6 +34,7 @@ require "rexml/document"
 require 'mimemagic'
 require 'curl'
 require 'securerandom'
+require 'date'
 
 module DynamicsCRM 
 


### PR DESCRIPTION
SecureRandom.uuid is called in `lib/dynamics_crm/xml/message_builder.rb` but SecureRandom is never required.

`lib/dynamics_crm/xml/attributes.rb` calls DateTime but Date is never required.
