### PR TITLE
Escape illegal xml characters

### DIFF
--- a/lib/dynamics_crm.rb
+++ b/lib/dynamics_crm.rb
@@ -42,6 +42,7 @@ require 'mimemagic'
 require 'curl'
 require 'securerandom'
 require 'date'
+require 'cgi'
 
 module DynamicsCRM
 

--- a/lib/dynamics_crm/xml/attributes.rb
+++ b/lib/dynamics_crm/xml/attributes.rb
@@ -23,6 +23,8 @@ module DynamicsCRM
             type = "EntityReference"
           when Entity
             type = "Entity"
+          when EntityCollection
+            type = "EntityCollection"
           when Query
             type = "QueryExpression"
           when FetchExpression

--- a/lib/dynamics_crm/xml/attributes.rb
+++ b/lib/dynamics_crm/xml/attributes.rb
@@ -66,6 +66,9 @@ module DynamicsCRM
             type = get_type(key, value)
           end
 
+          # escape strings to avoid xml parsing errors
+          value = CGI.escapeHTML(value) if type == "string"
+
           xml << build_xml(key, value, type)
         end
 

--- a/lib/dynamics_crm/xml/entity_collection.rb
+++ b/lib/dynamics_crm/xml/entity_collection.rb
@@ -37,6 +37,16 @@ module DynamicsCRM
         }
       end
 
+      def to_xml(options={})
+        options[:exclude_root] = true
+        namespace = options[:namespace] ? "#{options[:namespace]}:" : ''
+
+        entities_xml = entities.inject("") { |result,entity|
+          result << %Q{<#{namespace}Entity>#{entity.to_xml(options)}</#{namespace}Entity>}
+        }
+        %Q{<#{namespace}Entities>#{entities_xml}</#{namespace}Entities>}
+      end
+
     end
     # EntityCollection
   end


### PR DESCRIPTION
Escape xml strings to avoid errors when parsing illegal characters (&, <, >)