### PR TITLE
Use `request.bytesize` instead of `request.length`

### DIFF
--- a/lib/dynamics_crm/client.rb
+++ b/lib/dynamics_crm/client.rb
@@ -322,7 +322,7 @@ module DynamicsCRM
         # Set up headers.
         http.headers["Connection"] = "Keep-Alive"
         http.headers["Content-type"] = "application/soap+xml; charset=UTF-8"
-        http.headers["Content-length"] = request.length
+        http.headers["Content-length"] = request.bytesize
 
         http.ssl_verify_peer = false
         http.timeout = 120


### PR DESCRIPTION
I faced with problem sending non-ASCII characters in request (Russian letters). After debugging I've found that reason of this is incorrect setting of Content-Length header.