### PR TITLE
Rexml sanitization on username and password for ocp request builder

### DIFF
--- a/lib/dynamics_crm/xml/message_builder.rb
+++ b/lib/dynamics_crm/xml/message_builder.rb
@@ -44,9 +44,9 @@ module DynamicsCRM
                   <u:Expires>#{get_tomorrow_time}</u:Expires>
                 </u:Timestamp>
                 <o:UsernameToken u:Id="uuid-cdb639e6-f9b0-4c01-b454-0fe244de73af-1">
-                  <o:Username>#{username}</o:Username>
+                  <o:Username>#{REXML::Text.new(username).to_s}</o:Username>
                   <o:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">
-                    #{password}
+                    #{REXML::Text.new(password).to_s}
                   </o:Password>
                 </o:UsernameToken>
               </o:Security>


### PR DESCRIPTION
While building_ocp_request if the password has "<>" then the request construction breaks, adding REXML.text sanitizer works. The same has been done for on_premise_request and is missing for ocp_request. 