### PR TITLE
Adding new regions to determine region set

### DIFF
--- a/lib/dynamics_crm/client.rb
+++ b/lib/dynamics_crm/client.rb
@@ -297,10 +297,18 @@ module DynamicsCRM
 
     def determine_region
       case hostname
+      when /crm9\.dynamics\.com/
+        "urn:crmgcc:dynamics.com"
+      when /crm7\.dynamics\.com/
+        "urn:crmjpn:dynamics.com"
+      when /crm6\.dynamics\.com/
+        "urn:crmoce:dynamics.com"
       when /crm5\.dynamics\.com/
         "urn:crmapac:dynamics.com"
       when /crm4\.dynamics\.com/
         "urn:crmemea:dynamics.com"
+      when /crm2\.dynamics\.com/
+        "urn:crmsam:dynamics.com"
       when /\.dynamics\.com/
         "urn:crmna:dynamics.com"
       else


### PR DESCRIPTION
Microsoft have added new regions and I have included the newly added regions to determine_region method. Region identifier is verified by visiting https://disco.#crm_web_service_number#.dynamics.com/XRMServices/2011/Discovery.svc?singleWsdl for the various new web service URL's available in  https://msdn.microsoft.com/en-in/library/gg328127.aspx