### PR TITLE
Support ArrayOfEntity so one can create bound entities like ActivityParties on create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 InstalledFiles
 _yardoc
@@ -16,3 +17,4 @@ test/tmp
 test/version_tmp
 tmp
 vendor
+

--- a/lib/dynamics_crm/xml/entity.rb
+++ b/lib/dynamics_crm/xml/entity.rb
@@ -24,11 +24,19 @@ module DynamicsCRM
 
         return inner_xml if options[:exclude_root]
 
-        %Q{
-        <entity xmlns:a="http://schemas.microsoft.com/xrm/2011/Contracts">
-          #{inner_xml}
-        </entity>
-        }
+        if options[:in_array]
+          %Q{
+          <a:Entity>
+            #{inner_xml}
+          </a:Entity>
+          }
+        else
+          %Q{
+          <entity xmlns:a="http://schemas.microsoft.com/xrm/2011/Contracts">
+            #{inner_xml}
+          </entity>
+          }
+        end
       end
 
       def to_hash

--- a/spec/fixtures/entity_array_response.xml
+++ b/spec/fixtures/entity_array_response.xml
@@ -1,0 +1,37 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <Create xmlns="http://schemas.microsoft.com/xrm/2011/Contracts/Services" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+      <entity xmlns:a="http://schemas.microsoft.com/xrm/2011/Contracts">
+        <a:Attributes xmlns:b="http://schemas.datacontract.org/2004/07/System.Collections.Generic">
+          <a:KeyValuePairOfstringanyType>
+            <b:key>from</b:key>
+            <b:value i:type="a:ArrayOfEntity">
+              <a:Entity>
+                <a:Attributes>
+                  <a:KeyValuePairOfstringanyType>
+                    <b:key>partyid</b:key>
+                    <b:value i:type="a:EntityReference">
+                      <a:Id>f36aa96c-e7a5-4c70-8254-47c8ba947561</a:Id>
+                      <a:LogicalName>systemuser</a:LogicalName>
+                      <a:Name i:nil="true" />
+                    </b:value>
+                  </a:KeyValuePairOfstringanyType>
+                </a:Attributes>
+                <a:EntityState i:nil="true" />
+                <a:FormattedValues />
+                <a:Id>00000000-0000-0000-0000-000000000000</a:Id>
+                <a:LogicalName>activityparty</a:LogicalName>
+                <a:RelatedEntities />
+              </a:Entity>
+            </b:value>
+          </a:KeyValuePairOfstringanyType>
+        </a:Attributes>
+        <a:EntityState i:nil="true" />
+        <a:FormattedValues xmlns:b="http://schemas.datacontract.org/2004/07/System.Collections.Generic" />
+        <a:Id>00000000-0000-0000-0000-000000000000</a:Id>
+        <a:LogicalName>phonecall</a:LogicalName>
+        <a:RelatedEntities xmlns:b="http://schemas.datacontract.org/2004/07/System.Collections.Generic" />
+      </entity>
+    </Create>
+  </s:Body>
+</s:Envelope>

--- a/spec/lib/xml/entity_spec.rb
+++ b/spec/lib/xml/entity_spec.rb
@@ -60,4 +60,18 @@ describe DynamicsCRM::XML::Entity do
     end
   end
 
+  describe "entity with array" do
+    subject {
+      entity = DynamicsCRM::XML::Entity.new("activityparty")
+      entity.attributes = DynamicsCRM::XML::Attributes.new(
+          partyid: DynamicsCRM::XML::EntityReference.new("systemuser", "f36aa96c-e7a5-4c70-8254-47c8ba947561")
+      )
+      entity
+    }
+
+    context "#to_xml" do
+      it { expect(DynamicsCRM::XML::Attributes.new({to: [subject]}).to_xml).to include('<c:value i:type="a:ArrayOfEntity">') }
+    end
+  end
+
 end


### PR DESCRIPTION
This allows a user to create entities like:

```
from1 = DynamicsCRM::XML::Entity.new('activityparty')
from1.attributes = DynamicsCRM::XML::Attributes.new({partyid:
DynamicsCRM::XML::EntityReference.new("systemuser", @employee.id)})
to1  = DynamicsCRM::XML::Entity.new('activityparty')
to1.attributes = DynamicsCRM::XML::Attributes.new({partyid:
DynamicsCRM::XML::EntityReference.new("lead", @lead.id) })

body = { subject: "Subject for your phonecall", description: "Description", from: [from1], to: [to1] }
@call = @client.create('phonecall', body)
```

I haven't added a test for any of this yet, wanted thoughts first :)