### PR TITLE
Removed dependency on Curb

### DIFF
--- a/dynamics_crm.gemspec
+++ b/dynamics_crm.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'curb', '>= 0.8', '< 1.0.0'
   spec.add_runtime_dependency 'mimemagic', '>= 0.2', '< 4.0.0'
   spec.add_runtime_dependency 'builder', '>= 3.0.0', '< 4.0.0'
 

--- a/lib/dynamics_crm.rb
+++ b/lib/dynamics_crm.rb
@@ -46,8 +46,8 @@ require "dynamics_crm/client"
 require 'bigdecimal'
 require 'base64'
 require "rexml/document"
+require 'net/https'
 require 'mimemagic'
-require 'curl'
 require 'securerandom'
 require 'date'
 require 'cgi'


### PR DESCRIPTION
The Curb gem limits this gem to MRI only because of the native bindings to Curl. Curb is only used for posting requests, so using Net::HTTP here is a better idea.