### PR TITLE
[v0.9.2] Ruby v2.4 Integer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.2 (April 24, 2017)
+## 0.9.2 (August 31, 2021)
 * Support for Ruby v2.4 `Integer` class
 
 ## 0.9.1 (April 24, 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.2 (April 24, 2017)
+* Support for Ruby v2.4 `Integer` class
+
 ## 0.9.1 (April 24, 2017)
 * Entity metadata should return actual attributes if present #61
 * Support for crm3 and crm8 regions. #62
@@ -67,4 +70,3 @@
 ## 0.1.0 (March 23, 2014)
 
 *   Initial Release.
-

--- a/lib/dynamics_crm/metadata/filter_expression.rb
+++ b/lib/dynamics_crm/metadata/filter_expression.rb
@@ -15,7 +15,7 @@ module DynamicsCRM
 
       def get_type(value)
           type = value.class.to_s.downcase
-          type = "int" if type == "fixnum"
+          type = "int" if ["fixnum", "integer"].include?(type)
           type = "boolean" if ["trueclass", "falseclass"].include?(type)
           type
       end

--- a/lib/dynamics_crm/version.rb
+++ b/lib/dynamics_crm/version.rb
@@ -1,3 +1,3 @@
 module DynamicsCRM
-  VERSION = '0.9.1.1'
+  VERSION = '0.9.2'
 end

--- a/lib/dynamics_crm/xml/attributes.rb
+++ b/lib/dynamics_crm/xml/attributes.rb
@@ -13,6 +13,8 @@ module DynamicsCRM
         case value
           when ::Array
             type = "ArrayOfEntity"
+          when ::Integer
+            type = "int"
           when ::Fixnum
             type = "int"
           when ::BigDecimal, ::Float

--- a/lib/dynamics_crm/xml/condition_expression.rb
+++ b/lib/dynamics_crm/xml/condition_expression.rb
@@ -18,7 +18,7 @@ module DynamicsCRM
         return type unless type.nil?
 
         type = @values.first.class.to_s.downcase
-        if type == 'fixnum'
+        if ["fixnum", "integer"].include?(type)
           type = 'int'
         elsif %w(trueclass falseclass).include?(type)
           type = 'boolean'


### PR DESCRIPTION
- Updates to support `Integer` type for Ruby v2.4
- Incremented version to `v0.9.2`